### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/ui.frontend/src/utility/__tests__/http.test.ts
+++ b/ui.frontend/src/utility/__tests__/http.test.ts
@@ -14,6 +14,10 @@ describe('escapeColon function', () => {
     expect(escapeColon('http://')).toEqual('http%3A//');
   });
 
+  it('should replace ALL colon character in a given string with their encoded version', () => {
+    expect(escapeColon('http://://://://')).toEqual('http%3A//%3A//%3A//%3A//');
+  });
+
   it('should return the same string if no colon is present', () => {
     expect(escapeColon('http//')).toEqual('http//');
   });

--- a/ui.frontend/src/utility/http.ts
+++ b/ui.frontend/src/utility/http.ts
@@ -80,7 +80,7 @@ export const queryToParams = (statement: string) => {
 };
 
 export const escapeColon = (path: string) => {
-  return path.replace(':', '%3A');
+  return path.replace(/:/g, '%3A');
 };
 
 export const escapeUrl = (path: string) => {


### PR DESCRIPTION
Fixes [https://github.com/wizardry-tools/content-wizard/security/code-scanning/1](https://github.com/wizardry-tools/content-wizard/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of the colon character in the `path` string are replaced with the URL-encoded representation `%3A`. The best way to achieve this is to use a regular expression with the global flag (`g`) in the `replace` method. This will ensure that every colon in the string is replaced.

We will modify the `escapeColon` function to use a regular expression with the global flag. No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
