### PR TITLE
1.3.2 enhancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,40 +94,11 @@
                 <configuration>
                     <scmCommentPrefix>[maven-scm] :</scmCommentPrefix>
                     <preparationGoals>clean install</preparationGoals>
-                    <goals>install</goals>
+                    <goals>release</goals>
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
             </plugin>
-            <!-- Sonatype and GPG -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.4</version>
-                <executions>
-                    <execution>
-                        <id>sign-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <gpgArguments>
-                                <arg>--pinentry-mode</arg>
-                                <arg>loopback</arg>
-                            </gpgArguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.5.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <publishingServerId>central</publishingServerId>
-                </configuration>
-            </plugin>
+
 
             <!-- Maven Source Plugin -->
             <plugin>
@@ -261,13 +232,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.4</version>
+                    <version>3.2.7</version>
                 </plugin>
                 <!-- Sonatype Staging Deploy Plugin -->
                 <plugin>
                     <groupId>org.sonatype.central</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.5.0</version>
+                    <version>0.7.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>

--- a/ui.apps/src/main/content/jcr_root/apps/content-wizard/clientlibs/index.html
+++ b/ui.apps/src/main/content/jcr_root/apps/content-wizard/clientlibs/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Content Wizard</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/content-wizard/resources/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/content-wizard/resources/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/content-wizard/resources/favicon-16x16.png">
+    <link rel="manifest" href="/content-wizard/resources/site.webmanifest">
+    <link rel="mask-icon" href="/content-wizard/resources/safari-pinned-tab.svg" color="#1976d2">
+    <meta name="msapplication-TileColor" content="#1976d2">
+    <meta name="theme-color" content="#1976d2">
+  </head>
+  <link rel="stylesheet" href="/content-wizard/resources/css/bundle.css" type="text/css">
+  </head>
+  <body class="wizard-dark">
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="app-root"></div>
+
+  <script type="module" src="/content-wizard/resources/js/bundle.js"></script>
+  </body>
+</html>

--- a/ui.frontend/.env.development
+++ b/ui.frontend/.env.development
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 # This is for the FE Proxy. Typically not needed for production builds.
-VITE_HOST_URI=http://192.168.4.49:4502
+VITE_HOST_URI=http://localhost:4502
 
 # This is for cross-origin authentication. Typically not needed for production builds.
 VITE_AUTH_TOKEN='Basic YWRtaW46YWRtaW4='

--- a/ui.frontend/.env.development
+++ b/ui.frontend/.env.development
@@ -15,7 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 # This is for the FE Proxy. Typically not needed for production builds.
-VITE_HOST_URI=http://localhost:4502
+VITE_HOST_URI=http://192.168.4.49:4502
 
 # This is for cross-origin authentication. Typically not needed for production builds.
 VITE_AUTH_TOKEN='Basic YWRtaW46YWRtaW4='

--- a/ui.frontend/src/components/IDE/core/src/editor/components/result-explorer-editor.scss
+++ b/ui.frontend/src/components/IDE/core/src/editor/components/result-explorer-editor.scss
@@ -10,6 +10,8 @@
       height: 100%;
 
       .result-explorer-editor-toolbar {
+        position: sticky;
+        top: 0;
         display: inline-flex;
         padding: 2px;
         flex-grow: 0;
@@ -19,6 +21,7 @@
       }
 
       .result-explorer-editor-codemirror {
+        width: 95%;
         display: inline-flex;
         flex-grow: 2;
         flex-shrink: 1;

--- a/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
@@ -3,7 +3,14 @@ import type { SyntheticEvent } from 'react';
 import { Paper } from '@mui/material';
 import { useFields, useLogger } from '@/providers';
 import { useRenderCount } from '@/utility';
-import { authoringFields, msmFields, replicationFields, targetingFields, translationFields } from './fields';
+import {
+  authoringFields,
+  msmFields,
+  replicationFields,
+  targetingFields,
+  translationFields,
+  customFields,
+} from './fields';
 import { AccordionTab } from './AccordionTab';
 
 export const Accordion = () => {
@@ -49,6 +56,12 @@ export const Accordion = () => {
       />
       <AccordionTab
         fields={translationFields()}
+        fullConfig={fieldsConfig}
+        expanded={expanded}
+        onChange={handleAccordionChange}
+      />
+      <AccordionTab
+        fields={customFields()}
         fullConfig={fieldsConfig}
         expanded={expanded}
         onChange={handleAccordionChange}

--- a/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
@@ -9,7 +9,6 @@ import {
   replicationFields,
   targetingFields,
   translationFields,
-  customFields,
 } from './fields';
 import { AccordionTab } from './AccordionTab';
 
@@ -60,12 +59,12 @@ export const Accordion = () => {
         expanded={expanded}
         onChange={handleAccordionChange}
       />
-      <AccordionTab
-        fields={customFields()}
-        fullConfig={fieldsConfig}
-        expanded={expanded}
-        onChange={handleAccordionChange}
-      />
+      {/*<AccordionTab*/}
+      {/*  fields={customFields()}*/}
+      {/*  fullConfig={fieldsConfig}*/}
+      {/*  expanded={expanded}*/}
+      {/*  onChange={handleAccordionChange}*/}
+      {/*/>*/}
     </Paper>
   );
 };

--- a/ui.frontend/src/components/QueryWizard/Components/WizardCheckbox.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardCheckbox.tsx
@@ -29,7 +29,7 @@ export const WizardCheckbox = ({ field, disabled }: WizardInputProps) => {
 
   if (name) {
     return (
-      <FormGrid item>
+      <FormGrid item style={{ display: disabled ? 'none' : '' }}>
         <FormControlLabel
           label={label}
           control={
@@ -42,7 +42,6 @@ export const WizardCheckbox = ({ field, disabled }: WizardInputProps) => {
               onChange={handleCheckboxChange}
               required={required}
               disabled={disabled}
-              style={{ display: disabled ? 'none' : '' }}
             />
           }
         />

--- a/ui.frontend/src/components/QueryWizard/Components/WizardCheckbox.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardCheckbox.tsx
@@ -42,6 +42,7 @@ export const WizardCheckbox = ({ field, disabled }: WizardInputProps) => {
               onChange={handleCheckboxChange}
               required={required}
               disabled={disabled}
+              style={{ display: disabled ? 'none' : '' }}
             />
           }
         />

--- a/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
@@ -37,7 +37,7 @@ export const WizardInput = ({ field, defaultValue, disabled }: WizardInputProps)
   }, [fieldDispatcher, name, debouncedValue]);
 
   return (
-    <FormGrid item key={name}>
+    <FormGrid item key={name} style={{ display: disabled ? 'none' : '' }}>
       <Paper elevation={focused ? 4 : 1}>
         <TextField
           id={name}
@@ -52,7 +52,6 @@ export const WizardInput = ({ field, defaultValue, disabled }: WizardInputProps)
           disabled={disabled}
           required={required}
           placeholder={'/content'}
-          style={{ display: disabled ? 'none' : '' }}
         />
       </Paper>
     </FormGrid>

--- a/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
@@ -52,6 +52,7 @@ export const WizardInput = ({ field, defaultValue, disabled }: WizardInputProps)
           disabled={disabled}
           required={required}
           placeholder={'/content'}
+          style={{ display: disabled ? 'none' : '' }}
         />
       </Paper>
     </FormGrid>

--- a/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardInput.tsx
@@ -13,7 +13,7 @@ export const WizardInput = ({ field, defaultValue, disabled }: WizardInputProps)
   logger.debug({ message: `WizardInput[${renderCount}] render()` });
   const [value, setValue] = useState(defaultValue);
   const debouncedValue = useDebounce(value, 250);
-  const { name, label, required } = Field(field);
+  const { name, label, required, placeholder } = Field(field);
   const fieldDispatcher = useFieldDispatcher();
   // this state adds an elevation effect to the fields when focused. More noticeable on light-mode.
   const [focused, setFocused] = useState(false);
@@ -51,7 +51,7 @@ export const WizardInput = ({ field, defaultValue, disabled }: WizardInputProps)
           onChange={handleChange}
           disabled={disabled}
           required={required}
-          placeholder={'/content'}
+          placeholder={placeholder}
         />
       </Paper>
     </FormGrid>

--- a/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
@@ -3,24 +3,43 @@ import type { WizardInputProps } from '@/types';
 import { useRenderCount } from '@/utility';
 import { useLogger } from '@/providers';
 import { FormGrid } from './FormGrid';
-import { Fragment } from 'react';
+import { Fragment, ReactElement, useState } from 'react';
 
 export const WizardPredicateList = ({ disabled }: WizardInputProps) => {
   const logger = useLogger();
   const renderCount = useRenderCount();
+  const [testListItems, setTestListItems] = useState([] as ReactElement[]);
   logger.debug({ message: `WizardInput[${renderCount}] render()` });
+  // TODO: need to track Predicate List Items
+  // TODO: need to add Buttons for adding or removing Predicate List Items
+  
+  const testListItem = (index: number) => (
+    <ListItem alignItems="flex-start" key={index}>
+      <ListItemText
+        primary={`Custom Predicate ${index}`}
+        secondary={<Fragment>{`Custom Predicate ${index} Sub Text`}</Fragment>}
+      />
+    </ListItem>
+  );
+
+  const handleClick = () => {
+    logger.debug({ message: "clicked" });
+    setTestListItems((prevState) => {
+      const newIndex = prevState.length + 1;
+      return [...prevState, testListItem(newIndex)];
+    });
+  };
 
   return (
     <FormGrid item key={'test'} style={{ display: disabled ? 'none' : '' }}>
       <Paper elevation={1}>
         <List sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
-          <ListItem alignItems="flex-start">
-            <ListItemText
-              primary="Test List Item Primary Text"
-              secondary={<Fragment>{'Test List Item Secondary Text'}</Fragment>}
-            />
-          </ListItem>
+            {testListItems}
+            <ListItem button onClick={handleClick}>
+              <ListItemText primary={"add item"}  />
+            </ListItem>
         </List>
+        
       </Paper>
     </FormGrid>
   );

--- a/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
@@ -1,0 +1,27 @@
+import { Paper, List, ListItem, ListItemText } from '@mui/material';
+import type { WizardInputProps } from '@/types';
+import { useRenderCount } from '@/utility';
+import { useLogger } from '@/providers';
+import { FormGrid } from './FormGrid';
+import { Fragment } from 'react';
+
+export const WizardPredicateList = ({ disabled }: WizardInputProps) => {
+  const logger = useLogger();
+  const renderCount = useRenderCount();
+  logger.debug({ message: `WizardInput[${renderCount}] render()` });
+
+  return (
+    <FormGrid item key={'test'} style={{ display: disabled ? 'none' : '' }}>
+      <Paper elevation={1}>
+        <List sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
+          <ListItem alignItems="flex-start">
+            <ListItemText
+              primary="Test List Item Primary Text"
+              secondary={<Fragment>{'Test List Item Secondary Text'}</Fragment>}
+            />
+          </ListItem>
+        </List>
+      </Paper>
+    </FormGrid>
+  );
+};

--- a/ui.frontend/src/components/QueryWizard/Components/WizardSelect.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardSelect.tsx
@@ -40,7 +40,7 @@ export const WizardSelect = ({ field, disabled }: WizardInputProps) => {
   }, [options]);
 
   return (
-    <FormGrid item key={name}>
+    <FormGrid item key={name} style={{ display: disabled ? 'none' : '' }}>
       <FormControl>
         <Paper elevation={focused ? 4 : 1}>
           <InputLabel id={name + '-label'} color="secondary" required={required}>
@@ -63,7 +63,6 @@ export const WizardSelect = ({ field, disabled }: WizardInputProps) => {
             }}
             required={required}
             disabled={disabled}
-            style={{ display: disabled ? 'none' : '' }}
           >
             {menuItems}
           </Select>

--- a/ui.frontend/src/components/QueryWizard/Components/WizardSelect.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardSelect.tsx
@@ -63,6 +63,7 @@ export const WizardSelect = ({ field, disabled }: WizardInputProps) => {
             }}
             required={required}
             disabled={disabled}
+            style={{ display: disabled ? 'none' : '' }}
           >
             {menuItems}
           </Select>

--- a/ui.frontend/src/components/QueryWizard/Components/__tests__/WizardInput.test.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/__tests__/WizardInput.test.tsx
@@ -18,6 +18,7 @@ describe('WizardInput function', () => {
       category: 'targeting',
       fieldType: FieldTypes.WizardInput,
       value: undefined,
+      placeholder: '/content',
       name: 'path',
       label: 'mockLabel',
       required: true,
@@ -32,6 +33,7 @@ describe('WizardInput function', () => {
     // Checking if the component and initial props are correctly rendered
     expect(textField).toHaveProperty('value', mockDefaultValue);
     expect(textField).toHaveAttribute('name', mockField.name);
+    expect(textField).toHaveAttribute('placeholder', mockField.placeholder);
     expect(textField).toHaveAttribute('required');
 
     const newInputValue = 'new mock value';
@@ -48,6 +50,7 @@ describe('WizardInput function', () => {
       category: 'targeting',
       fieldType: FieldTypes.WizardInput,
       value: undefined,
+      placeholder: '/content',
       name: 'path',
       label: 'mockLabel',
       required: true,

--- a/ui.frontend/src/components/QueryWizard/Components/fields.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/fields.ts
@@ -45,6 +45,17 @@ export const defaultFields: FieldsConfig = {
     options: contentTypes,
     category: 'targeting',
   }),
+  customContentType: Field({
+    name: 'customContentType',
+    label: 'Custom Node Type',
+    fieldType: FieldTypes.WizardInput,
+    value: 'nt:unstructured',
+    required: true,
+    isDisabled: (fields: FieldsConfig) => {
+      return fields.type.value !== 'custom';
+    },
+    category: 'targeting',
+  }),
   targetType: Field({
     name: 'targetType',
     label: 'Target Type',

--- a/ui.frontend/src/components/QueryWizard/Components/fields.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/fields.ts
@@ -6,6 +6,7 @@ import { WizardSelect } from './WizardSelect';
 import { WizardCheckbox } from './WizardCheckbox';
 import { WizardDatePicker } from './WizardDatePicker';
 import { WizardSlider } from './WizardSlider';
+import { WizardPredicateList } from './WizardPredicateList';
 
 export const Field = (field: FieldConfig) => {
   const render = field.render ?? true;
@@ -21,6 +22,7 @@ export const FieldTypes: Record<string, ElementType> = {
   WizardCheckbox: WizardCheckbox,
   WizardDatePicker: WizardDatePicker,
   WizardSlider: WizardSlider,
+  WizardPredicateList: WizardPredicateList,
 };
 
 /**
@@ -264,6 +266,13 @@ export const defaultFields: FieldsConfig = {
     value: 100,
     category: 'targeting',
   }),
+  customPredicates: Field({
+    name: 'customPredicates',
+    label: 'Custom Predicates',
+    fieldType: FieldTypes.WizardPredicateList,
+    value: [],
+    category: 'custom',
+  }),
 };
 
 export const targetingFields = () => {
@@ -280,4 +289,7 @@ export const msmFields = () => {
 };
 export const translationFields = () => {
   return Object.values(defaultFields).filter((field) => field.category === 'translation');
+};
+export const customFields = () => {
+  return Object.values(defaultFields).filter((field) => field.category === 'custom');
 };

--- a/ui.frontend/src/components/QueryWizard/Components/fields.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/fields.ts
@@ -35,6 +35,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Content Path',
     fieldType: FieldTypes.WizardInput,
     value: '/content/we-retail',
+    placeholder: 'Enter Search Path (eg; /content/we-retail)',
     required: true,
     category: 'targeting',
   }),
@@ -52,6 +53,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Custom Node Type',
     fieldType: FieldTypes.WizardInput,
     value: 'nt:unstructured',
+    placeholder: 'Enter JCR Node Type (eg; nt:unstructured)',
     required: true,
     isDisabled: (fields: FieldsConfig) => {
       return fields.type.value !== 'custom';
@@ -71,6 +73,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Target Resource Type',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter Resource Type (eg; we-retail/components/text)',
     isDisabled: (fields: FieldsConfig) => {
       const type = fields.targetType.value;
       return !type || type === 'none' || type === 'text';
@@ -82,6 +85,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Text Search',
     fieldType: FieldTypes.WizardInput,
     value: 'winter',
+    placeholder: 'Enter Search Term (eg; surfing)',
     isDisabled: (fields: FieldsConfig) => {
       return fields.targetType.value !== 'text';
     },
@@ -92,6 +96,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Created By',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter User Name (eg; admin)',
     category: 'authoring',
   }),
   lastModifiedBy: Field({
@@ -99,6 +104,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Last Modified By',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter User Name (eg; admin)',
     category: 'authoring',
   }),
   lastReplicatedBy: Field({
@@ -106,6 +112,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Last Replicated By',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter User Name (eg; admin)',
     isDisabled: (fields: FieldsConfig) => !!fields.isUnpublished.value,
     category: 'replication',
   }),
@@ -114,6 +121,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Last Rolledout By',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter User Name (eg; admin)',
     isDisabled: (fields: FieldsConfig) => !fields.isLiveCopy.value,
     category: 'msm',
   }),
@@ -122,6 +130,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Target Language',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter Language Code (eg; en)',
     category: 'translation',
   }),
   created: Field({
@@ -220,6 +229,7 @@ export const defaultFields: FieldsConfig = {
     label: 'Inheritance Cancelled for Property',
     fieldType: FieldTypes.WizardInput,
     value: '',
+    placeholder: 'Enter Property Name (eg; jcr:title)',
     isDisabled: (fields: FieldsConfig) => !fields.isLiveCopy.value,
     category: 'msm',
   }),

--- a/ui.frontend/src/components/QueryWizard/Components/index.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/index.ts
@@ -8,6 +8,7 @@ export * from './QueryHandler';
 export * from './WizardInput';
 export * from './WizardDatePicker';
 export * from './WizardCheckbox';
+export * from './WizardPredicateList';
 export * from './WizardSelect';
 export * from './WizardSlider';
 export * from './StatementWindow';

--- a/ui.frontend/src/components/QueryWizard/Components/predicates.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/predicates.ts
@@ -56,10 +56,13 @@ export const predicates: PredicatesConfig = {
     type: 'property',
     configInject: (fields: FieldsConfig): string => {
       // TODO: This should inject the TargetResourceType into a property PredicateType with these properties being targeted
+      const prefix = ['page', 'xf', 'cf'].includes(fields.type.value as string) ? 'jcr:content/' : '';
       if (fields.targetType.value === 'resource') {
-        return 'sling:resourceType';
+        return prefix + 'sling:resourceType';
+      } else if (fields.targetType.value === 'cfmodel') {
+        return prefix + 'data/cq:model';
       } else {
-        return 'cq:template';
+        return prefix + 'cq:template';
       }
     },
     useConfig: true,
@@ -74,15 +77,35 @@ export const predicates: PredicatesConfig = {
   }),
   lastModifiedBy: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastModifiedBy',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset'].includes(fields.type.value as string)) {
+        return 'jcr:content/jcr:lastModifiedBy';
+      } else if (['page', 'xf'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastModifiedBy';
+      }
+      return 'cq:lastModifiedBy';
+    },
+    useConfig: true,
   }),
   lastReplicatedBy: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicatedBy',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastReplicatedBy';
+      }
+      return 'cq:lastReplicatedBy';
+    },
+    useConfig: true,
   }),
   lastRolledoutBy: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicated',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastRolledoutBy';
+      }
+      return 'cq:lastRolledoutBy';
+    },
+    useConfig: true,
   }),
   language: Predicate({
     type: 'property',
@@ -94,32 +117,76 @@ export const predicates: PredicatesConfig = {
   }),
   lastModified: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastModified',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset'].includes(fields.type.value as string)) {
+        return 'jcr:content/jcr:lastModified';
+      } else if (['page', 'xf'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastModified';
+      }
+      return 'cq:lastModified';
+    },
+    useConfig: true,
   }),
   lastReplicated: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicated',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastReplicated';
+      }
+      return 'cq:lastReplicated';
+    },
+    useConfig: true,
   }),
   lastRolledout: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastRolledout',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastRolledout';
+      }
+      return 'cq:lastRolledout';
+    },
+    useConfig: true,
   }),
   isPublished: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicationAction',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastReplicationAction';
+      }
+      return 'cq:lastReplicationAction';
+    },
+    useConfig: true,
   }),
   isUnpublished: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicationAction',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastReplicationAction';
+      }
+      return 'cq:lastReplicationAction';
+    },
+    useConfig: true,
     operation: 'not',
   }),
   isDeactivated: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:lastReplicationAction',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:lastReplicationAction';
+      }
+      return 'cq:lastReplicationAction';
+    },
+    useConfig: true,
   }),
   isBlueprint: Predicate({
     type: 'property',
-    property: 'jcr:content/jcr:mixinTypes',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/jcr:mixinTypes';
+      }
+      return 'jcr:mixinTypes';
+    },
+    useConfig: true,
     operation: 'unequals',
   }),
   isLiveCopy: Predicate({
@@ -128,15 +195,33 @@ export const predicates: PredicatesConfig = {
   }),
   isSuspended: Predicate({
     type: 'property',
-    property: 'jcr:content/jcr:mixinTypes',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/jcr:mixinTypes';
+      }
+      return 'jcr:mixinTypes';
+    },
+    useConfig: true,
   }),
   hasCancelledPropertyInheritance: Predicate({
     type: 'property',
-    property: 'jcr:content/jcr:mixinTypes',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/jcr:mixinTypes';
+      }
+      return 'jcr:mixinTypes';
+    },
+    useConfig: true,
   }),
   inheritanceCancelledProperty: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:propertyInheritanceCancelled',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:propertyInheritanceCancelled';
+      }
+      return 'cq:propertyInheritanceCancelled';
+    },
+    useConfig: true,
   }),
   hasLocalContent: Predicate({
     // not in use
@@ -148,12 +233,24 @@ export const predicates: PredicatesConfig = {
   }),
   isLanguageCopy: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:translationSourcePath',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:translationSourcePath';
+      }
+      return 'cq:translationSourcePath';
+    },
+    useConfig: true,
     operation: 'exists',
   }),
   hasBeenTranslated: Predicate({
     type: 'property',
-    property: 'jcr:content/cq:translationStatus',
+    configInject: (fields: FieldsConfig): string => {
+      if (['cf', 'asset', 'xf', 'page'].includes(fields.type.value as string)) {
+        return 'jcr:content/cq:translationStatus';
+      }
+      return 'cq:translationStatus';
+    },
+    useConfig: true,
   }),
   limit: Predicate({
     type: 'limit',

--- a/ui.frontend/src/components/QueryWizard/Components/predicates.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/predicates.ts
@@ -37,11 +37,16 @@ export const predicates: PredicatesConfig = {
       if (contentType) {
         if (contentType === 'cf') {
           return `type=${contentTypeMap[contentType]}\ncontentfragment=true\n`;
+        } else if (contentType !== 'custom') {
+          return `type=${contentTypeMap[contentType]}\n`;
         }
-        return `type=${contentTypeMap[contentType]}\n`;
       }
       return '';
     },
+  }),
+  customContentType: Predicate({
+    type: 'type',
+    rawInject: (value: InputValue) => `type=${value as string}\n`,
   }),
   targetType: Predicate({
     type: null,

--- a/ui.frontend/src/components/QueryWizard/Components/predicates.ts
+++ b/ui.frontend/src/components/QueryWizard/Components/predicates.ts
@@ -261,4 +261,7 @@ export const predicates: PredicatesConfig = {
       return '';
     },
   }),
+  customPredicates: Predicate({
+    type: 'predicateList',
+  }),
 };

--- a/ui.frontend/src/components/Results/ResultTable/ResultTableFooter.tsx
+++ b/ui.frontend/src/components/Results/ResultTable/ResultTableFooter.tsx
@@ -1,9 +1,10 @@
 import { memo, useMemo } from 'react';
-import { TableFooter, TablePagination, TableRow } from '@mui/material';
+import { InputBase, TableFooter, TablePagination, TableRow } from '@mui/material';
 import type { ResultTableFooterProps } from '@/types';
 import { useLogger, useResults } from '@/providers';
 import { usePaperTheme } from '@/utility';
 import { TablePaginationActions } from './TablePaginationActions';
+import { styled } from '@mui/system';
 
 /**
  * This component is the Table Footer for the {@link ResultTable}. It contains the {@link TablePagination}.
@@ -24,6 +25,30 @@ export const ResultTableFooter = memo((props: ResultTableFooterProps) => {
       zIndex: 2,
     },
   });
+  const selectMenuTheme = usePaperTheme({
+    styles: {
+      boxShadow: 'none',
+    },
+  });
+
+  const BootstrapInput = styled(InputBase)(({ theme }) => {
+    return {
+      'label + &': {
+        marginTop: theme.spacing(3),
+      },
+      '& .MuiInputBase-input': {
+        borderRadius: 4,
+        '&:focus': {
+          borderRadius: 4,
+          borderColor: '#80bdff',
+          boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+        },
+        '.MuiTablePagination-menuItem': {
+          ...selectMenuTheme,
+        },
+      },
+    };
+  });
 
   return (
     <TableFooter sx={footerTheme}>
@@ -43,6 +68,7 @@ export const ResultTableFooter = memo((props: ResultTableFooterProps) => {
                 'aria-label': 'rows per page',
               },
               native: true,
+              input: <BootstrapInput />,
             },
           }}
           onPageChange={onPageChange}

--- a/ui.frontend/src/constants/fields.ts
+++ b/ui.frontend/src/constants/fields.ts
@@ -6,4 +6,5 @@ export const fieldCategories: FieldCategories = {
   replication: 'Filter by Replication activity',
   msm: 'Filter for MSM content',
   translation: 'Filter for Translated content',
+  custom: 'Filter with Custom Predicates',
 };

--- a/ui.frontend/src/constants/query.ts
+++ b/ui.frontend/src/constants/query.ts
@@ -32,6 +32,8 @@ export const contentTypes: Record<ContentType, ContentTypeLabel> = {
   asset: 'DAM Asset',
   cf: 'CF (Content Fragment)',
   child: 'Child (Component)',
+  custom: 'Custom Node Type',
+  all: 'All Node Types',
 };
 
 export const contentTypeMap: Record<ContentType, ContentTypeProperty> = {
@@ -40,6 +42,8 @@ export const contentTypeMap: Record<ContentType, ContentTypeProperty> = {
   asset: 'dam:Asset',
   cf: 'dam:Asset',
   child: 'nt:unstructured',
+  custom: 'custom',
+  all: 'nt:base',
 };
 
 export const defaultAdvancedQueries: QueryMap = {

--- a/ui.frontend/src/constants/query.ts
+++ b/ui.frontend/src/constants/query.ts
@@ -22,6 +22,7 @@ export const targetTypes: Record<TargetType, TargetTypeLabel> = {
   none: 'None',
   resource: 'Resource Type',
   template: 'Template Type',
+  cfmodel: 'CF Model Type',
   text: 'Full Text Search',
 };
 

--- a/ui.frontend/src/types/ContentType.ts
+++ b/ui.frontend/src/types/ContentType.ts
@@ -1,9 +1,11 @@
-export type ContentType = 'page' | 'xf' | 'asset' | 'cf' | 'child';
+export type ContentType = 'page' | 'xf' | 'asset' | 'cf' | 'child' | 'custom' | 'all';
 export type ContentTypeLabel =
   | 'Page'
   | 'XF (Experience Fragment)'
   | 'DAM Asset'
   | 'CF (Content Fragment)'
-  | 'Child (Component)';
+  | 'Child (Component)'
+  | 'Custom Node Type'
+  | 'All Node Types';
 
-export type ContentTypeProperty = 'cq:Page' | 'dam:Asset' | 'nt:unstructured';
+export type ContentTypeProperty = 'cq:Page' | 'dam:Asset' | 'nt:unstructured' | 'custom' | 'nt:base';

--- a/ui.frontend/src/types/Fields.ts
+++ b/ui.frontend/src/types/Fields.ts
@@ -30,9 +30,10 @@ export type FieldConfigName =
   | 'hasMsmGhosts'
   | 'isLanguageCopy'
   | 'hasBeenTranslated'
-  | 'limit';
+  | 'limit'
+  | 'customPredicates';
 
-export type FieldConfigCategory = 'targeting' | 'authoring' | 'replication' | 'msm' | 'translation';
+export type FieldConfigCategory = 'targeting' | 'authoring' | 'replication' | 'msm' | 'translation' | 'custom';
 export type FieldCategoryLabel = string;
 export type FieldCategories = Record<FieldConfigCategory, FieldCategoryLabel>;
 

--- a/ui.frontend/src/types/Fields.ts
+++ b/ui.frontend/src/types/Fields.ts
@@ -54,6 +54,7 @@ export type FieldConfig = {
   readonly fieldType: ElementType;
   value: InputValue;
   readonly checkboxValue?: InputValue;
+  readonly placeholder?: string;
   required?: boolean;
   isDisabled?: DisabledCallback;
   onChange?: onChangeCallback;

--- a/ui.frontend/src/types/Fields.ts
+++ b/ui.frontend/src/types/Fields.ts
@@ -5,6 +5,7 @@ import type { Query } from './Query';
 export type FieldConfigName =
   | 'path'
   | 'type'
+  | 'customContentType'
   | 'targetType'
   | 'targetResourceType'
   | 'fulltext'

--- a/ui.frontend/src/types/Predicate.ts
+++ b/ui.frontend/src/types/Predicate.ts
@@ -1,17 +1,35 @@
 import type { FieldConfigName, FieldsConfig, InputValue } from './Fields';
 
-export type PredicateType = 'fulltext' | 'path' | 'type' | 'nodename' | 'property' | 'limit' | 'isLiveCopy' | null;
+export type PredicateType =
+  | 'fulltext'
+  | 'path'
+  | 'type'
+  | 'nodename'
+  | 'property'
+  | 'limit'
+  | 'isLiveCopy'
+  | 'predicateList'
+  | null;
 
 export type RawInjectCallback = (value: InputValue, prefix?: string) => string;
 export type PredicateValidityCallback = (value: InputValue) => boolean;
 export type ConfigInjectCallback = (fields: FieldsConfig) => string;
+
+export type PredicateOperationType =
+  | 'exists'
+  | 'not'
+  | 'like'
+  | 'equals'
+  | 'unequals'
+  | 'equalsIgnoreCase'
+  | 'unequalsIgnoreCase';
 
 export type PredicateConfig = {
   readonly type: PredicateType;
   readonly raw?: string; // static predicate value
   readonly rawInject?: RawInjectCallback; // simple predicate based on string injection
   readonly valueRequired?: boolean;
-  readonly operation?: string;
+  readonly operation?: PredicateOperationType;
   readonly property?: string;
   readonly configInject?: ConfigInjectCallback; // relative property path for the query, uses a callback since some fields need dynamic definitions.
   readonly useConfig?: boolean;

--- a/ui.frontend/src/types/TargetType.ts
+++ b/ui.frontend/src/types/TargetType.ts
@@ -1,3 +1,3 @@
-export type TargetType = 'none' | 'resource' | 'template' | 'text';
+export type TargetType = 'none' | 'resource' | 'template' | 'text' | 'cfmodel';
 
-export type TargetTypeLabel = 'None' | 'Resource Type' | 'Template Type' | 'Full Text Search';
+export type TargetTypeLabel = 'None' | 'Resource Type' | 'Template Type' | 'Full Text Search' | 'CF Model Type';


### PR DESCRIPTION
- [x] Removed Maven Release plugin
- [x] Fixed sticky position for the Results Explorer JSON Copy button
- [x] Fixed styling issue with Results Explorer Pagination Count
- [x] Fixed width of Results Explorer JSON
- [x] Added Logic to hide Query Wizard fields when they are disabled
- [x] Added support for Input Field Placeholder text
- [x] Added support for targeting Content Fragments in Query Wizard
- [x] Added support for targeting ALL node types (nt:base) in Query Wizard
- [x] Added support to specify Custom Node Types in Query Wizard
- [x] Added logic that dynamically prepends "jcr:content/" to properties when targeting certain Node Types.
- [x] Started on logic to support custom predicates. It's currently disabled.