### PR TITLE
Implement custom predicates: data state, query generation, and accord…

### DIFF
--- a/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/Accordion.tsx
@@ -5,6 +5,7 @@ import { useFields, useLogger } from '@/providers';
 import { useRenderCount } from '@/utility';
 import {
   authoringFields,
+  customFields,
   msmFields,
   replicationFields,
   targetingFields,
@@ -59,12 +60,12 @@ export const Accordion = () => {
         expanded={expanded}
         onChange={handleAccordionChange}
       />
-      {/*<AccordionTab*/}
-      {/*  fields={customFields()}*/}
-      {/*  fullConfig={fieldsConfig}*/}
-      {/*  expanded={expanded}*/}
-      {/*  onChange={handleAccordionChange}*/}
-      {/*/>*/}
+      <AccordionTab
+        fields={customFields()}
+        fullConfig={fieldsConfig}
+        expanded={expanded}
+        onChange={handleAccordionChange}
+      />
     </Paper>
   );
 };

--- a/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
+++ b/ui.frontend/src/components/QueryWizard/Components/WizardPredicateList.tsx
@@ -1,45 +1,86 @@
-import { Paper, List, ListItem, ListItemText } from '@mui/material';
-import type { WizardInputProps } from '@/types';
+import { useCallback, useEffect, useState } from 'react';
+import { Box, IconButton, List, ListItem, Paper, TextField, Tooltip } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import type { CustomPredicate, WizardInputProps } from '@/types';
 import { useRenderCount } from '@/utility';
-import { useLogger } from '@/providers';
+import { useFieldDispatcher, useLogger } from '@/providers';
+import { Field } from './fields';
 import { FormGrid } from './FormGrid';
-import { Fragment, ReactElement, useState } from 'react';
 
-export const WizardPredicateList = ({ disabled }: WizardInputProps) => {
+const emptyPredicate = (): CustomPredicate => ({ property: '', value: '' });
+
+export const WizardPredicateList = ({ field, defaultValue, disabled }: WizardInputProps) => {
   const logger = useLogger();
   const renderCount = useRenderCount();
-  const [testListItems, setTestListItems] = useState([] as ReactElement[]);
-  logger.debug({ message: `WizardInput[${renderCount}] render()` });
-  // TODO: need to track Predicate List Items
-  // TODO: need to add Buttons for adding or removing Predicate List Items
-  
-  const testListItem = (index: number) => (
-    <ListItem alignItems="flex-start" key={index}>
-      <ListItemText
-        primary={`Custom Predicate ${index}`}
-        secondary={<Fragment>{`Custom Predicate ${index} Sub Text`}</Fragment>}
-      />
-    </ListItem>
+  logger.debug({ message: `WizardPredicateList[${renderCount}] render()` });
+
+  const { name } = Field(field);
+  const fieldDispatcher = useFieldDispatcher();
+  const [items, setItems] = useState<CustomPredicate[]>(
+    Array.isArray(defaultValue) ? (defaultValue as CustomPredicate[]) : [],
   );
 
-  const handleClick = () => {
-    logger.debug({ message: "clicked" });
-    setTestListItems((prevState) => {
-      const newIndex = prevState.length + 1;
-      return [...prevState, testListItem(newIndex)];
-    });
-  };
+  useEffect(() => {
+    fieldDispatcher({ name, value: items, type: 'UPDATE_VALUE' });
+  }, [fieldDispatcher, name, items]);
+
+  const handleAdd = useCallback(() => {
+    setItems((prev) => [...prev, emptyPredicate()]);
+  }, []);
+
+  const handleRemove = useCallback((index: number) => {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleChange = useCallback((index: number, key: keyof CustomPredicate, val: string) => {
+    setItems((prev) => prev.map((item, i) => (i === index ? { ...item, [key]: val } : item)));
+  }, []);
 
   return (
-    <FormGrid item key={'test'} style={{ display: disabled ? 'none' : '' }}>
-      <Paper elevation={1}>
-        <List sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
-            {testListItems}
-            <ListItem button onClick={handleClick}>
-              <ListItemText primary={"add item"}  />
+    <FormGrid item key={name} style={{ display: disabled ? 'none' : '' }}>
+      <Paper elevation={1} sx={{ width: '100%' }}>
+        <List disablePadding>
+          {items.map((item, index) => (
+            <ListItem
+              key={index}
+              disableGutters
+              sx={{ gap: 1, px: 1, py: 0.5, flexWrap: 'wrap', alignItems: 'flex-start' }}
+            >
+              <TextField
+                size="small"
+                label="Property"
+                placeholder="jcr:content/myProperty"
+                value={item.property}
+                onChange={(e) => handleChange(index, 'property', e.target.value)}
+                sx={{ flex: '1 1 180px' }}
+                color="secondary"
+              />
+              <TextField
+                size="small"
+                label="Value"
+                value={item.value}
+                onChange={(e) => handleChange(index, 'value', e.target.value)}
+                sx={{ flex: '1 1 180px' }}
+                color="secondary"
+              />
+              <Tooltip title="Remove predicate">
+                <Box display="flex" alignItems="center">
+                  <IconButton size="small" onClick={() => handleRemove(index)} aria-label="remove predicate">
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Tooltip>
             </ListItem>
+          ))}
+          <ListItem disableGutters sx={{ px: 1, py: 0.5 }}>
+            <Tooltip title="Add custom predicate">
+              <IconButton size="small" onClick={handleAdd} color="secondary" aria-label="add predicate">
+                <AddIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </ListItem>
         </List>
-        
       </Paper>
     </FormGrid>
   );

--- a/ui.frontend/src/providers/FieldsProvider/context.ts
+++ b/ui.frontend/src/providers/FieldsProvider/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 import type { Dispatch } from 'react';
-import type { DateRange, FieldConfigAction, FieldsConfig, InputValue, PredicateConfig } from '@/types';
+import type { CustomPredicate, DateRange, FieldConfigAction, FieldsConfig, InputValue, PredicateConfig } from '@/types';
 import { predicates } from '@/components/QueryWizard/Components';
 
 export const FieldsConfigContext = createContext<FieldsConfig>(null!);
@@ -121,6 +121,20 @@ export const generateQuery = (fields: FieldsConfig): string => {
         if (predicate.raw) {
           // if raw, nothing to build, return the raw statement
           return predicate.raw + '\n';
+        }
+        if (predicate.type === 'predicateList') {
+          const items = (value as CustomPredicate[]).filter((item) => item.property && item.value);
+          if (!items.length) return '';
+          return items
+            .map((item) => {
+              const idx = `${propCounter}_`;
+              propCounter++;
+              let s = `${idx}property=${item.property}\n`;
+              s += `${idx}property.value=${item.value}\n`;
+              if (item.operation) s += `${idx}property.operation=${item.operation}\n`;
+              return s;
+            })
+            .join('');
         }
         // property strings, configInject functions, and operation strings require predicate statements to have an indexed prefix
         if (predicate.property ?? predicate.configInject ?? predicate.operation) {

--- a/ui.frontend/src/types/Fields.ts
+++ b/ui.frontend/src/types/Fields.ts
@@ -43,7 +43,12 @@ export type DateRange = {
   upperBound: DayTime | undefined;
 };
 export type NumberValue = number | number[];
-export type InputValue = DateRange | NumberValue | string | boolean | null | undefined;
+export type CustomPredicate = {
+  property: string;
+  value: string;
+  operation?: string;
+};
+export type InputValue = DateRange | NumberValue | string | boolean | CustomPredicate[] | null | undefined;
 
 export type onChangeCallback = (value: InputValue) => void;
 export type DisabledCallback = (fields: FieldsConfig) => boolean;


### PR DESCRIPTION
…ion tab

- Add CustomPredicate type and expand InputValue to include CustomPredicate[]
- Rewrite WizardPredicateList from JSX-in-state stub to a functional component that stores predicate data objects and dispatches via useFieldDispatcher
- Add predicateList handling in generateQuery so custom predicates emit correctly indexed N_property / N_property.value QueryBuilder statements, sharing propCounter with other property predicates to avoid index collisions
- Uncomment and wire the Custom Predicates accordion tab in Accordion.tsx